### PR TITLE
return Promise.reject when passwords do not match

### DIFF
--- a/.core/lib/user.js
+++ b/.core/lib/user.js
@@ -374,7 +374,7 @@ User.save = async (params, options) => {
         if (params.password === null) {
             op.del(params, 'password');
         } else if (!params.confirm || params.password !== params.confirm) {
-            return new Error('passwords do not match');
+            return Promise.reject(new Error('passwords do not match'));
         }
     }
 


### PR DESCRIPTION
This allows clients to receive the validation 400 error message when passwords don't match